### PR TITLE
Fixed PHP 7.4 issue in API/ParamSigner::is_utf8()

### DIFF
--- a/API/ParamSigner.php
+++ b/API/ParamSigner.php
@@ -236,6 +236,7 @@ class ParamSigner
 
     public function is_utf8($value)
     {
+        $value = (string)$value;
         $length = strlen($value);
         for ($i = 0; $i < $length; $i++) {
             $c = ord($value[$i]);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ipgpay/ipgpay-magento2-payment-module",
   "description": "IPGPAY payment gateway implementation for Magento2",
   "type": "magento2-module",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": [
     "ipgpay",
     "magento2",


### PR DESCRIPTION
Fixed issue where PHP 7.4 would fail in API/ParamSigner::is_utf8() when a float or null is passed in.

I tested using type hinting in the is_utf8() but decided that casting the value as string is safer and doesn't create new requirements for the plugin. It also handles null values properly.